### PR TITLE
misses first of each group of four

### DIFF
--- a/nmea.js
+++ b/nmea.js
@@ -91,7 +91,7 @@ exports.parsers = {
         // $GPGSV,3,1,12, 05,58,322,36, 02,55,032,, 26,50,173,, 04,31,085,
         var numRecords = (fields.length - 4) / 4,
             sats = [];
-        for (var i=1; i < numRecords; i++) {
+        for (var i=0; i < numRecords; i++) {
             var offset = i * 4 + 4;
             sats.push({id: fields[offset],
                        elevationDeg: +fields[offset+1],


### PR DESCRIPTION
with v=1
N3011.8281 W09747.9048
30.1971, -97.7984
satsInView: 11
Sats:51,32,14,
Sats:01,30,25,
Sats:20,16,

with v=0
N3011.8268 W09747.9037
30.1971, -97.7984
satsInView: 11
Sats:31,51,32,14,
Sats:22,01,30,25,
Sats:11,20,16,

I used my test program here: https://gist.github.com/1861056
