### PR TITLE
Parser global leak

### DIFF
--- a/nmea.js
+++ b/nmea.js
@@ -212,7 +212,7 @@ exports.parse = function(line) {
             talker_id = fields[0].substr(1, 2);
             msg_fmt = fields[0].substr(3);
         }
-        parser = exports.parsers[msg_fmt];
+        var parser = exports.parsers[msg_fmt];
         if (parser) {
             var val = parser(fields);
             val.talker_id = talker_id;


### PR DESCRIPTION
Exports.parse contained a variable that didn't have a var statement. It gets picked up by Mocha as a global leak. It is not a global leak per se but it is a leak within the nmea.js file and might lead to weird behaviour in the future.

Please update npm too if you accept the pull request :)
